### PR TITLE
Add --recent/-r flag to CLI to include recently modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ When developers want to get help from ChatGPT, Claude, or other LLMs about their
 - **Error Handling**: Gracefully handles permission errors and provides helpful messages
 - **Flexible Output**: Write to stdout or save to a file
 - **Pattern Matching**: Include/exclude files using glob patterns
+- **Recent Changes Mode**: Use `--recent` (`-r`) to include only files modified in the last 7 days, with a "Recent Changes" section in the output.
+
 
 ## Installation
 
@@ -121,6 +123,7 @@ repo-contextr .
 | `--include` | - | Pattern to include files (glob pattern) | `--include "*.py"` |
 | `--version` | `-v` | Show version and exit | `-v` |
 | `--help` | `-h` | Show help message | `-h` |
+| `--recent` | `-r` | Include only files modified in the last 7 days | `--recent` |
 
 ### Advanced Examples
 
@@ -136,6 +139,12 @@ repo-contextr README.md src/main.py pyproject.toml
 
 # Analyze a different repository
 repo-contextr /path/to/other/project -o other-project.txt
+
+# Include only files modified in the last 7 days
+uv run main.py --recent
+
+# Combine with include filter (only recent Python files)
+uv run main.py --recent --include "*.py"
 ```
 
 ## Output Format
@@ -160,7 +169,12 @@ Each file's content with:
 - Appropriate syntax highlighting language tags
 - Truncation notices for large files
 
-### 5. Summary Statistics
+### 5. Recent Changes (when --recent is used)
+- Shows only files modified in the last 7 days
+- Includes file contents and statistics for those files
+- Adds a summary line indicating how many recent files were found
+
+### 6. Summary Statistics
 - Total number of files processed
 - Total lines of code
 
@@ -191,28 +205,21 @@ src/
 package.json
 README.md
 
-## File Contents
-
-### File: src/main.py
+## Recent Changes
+### File: main.py
 ```python
-def main():
-    print("Hello, World!")
+Main entry point for contextr CLI tool
+"""
+from src.contextr.cli import app
 
 if __name__ == "__main__":
-    main()
-```
-
-### File: package.json
-```json
-{
-  "name": "my-project",
-  "version": "1.0.0"
-}
+    app()
 ```
 
 ## Summary
 - Total files: 2
 - Total lines: 8
+- Recent files (last 7 days): 1
 ````
 
 ## What Files Are Included

--- a/src/contextr/cli.py
+++ b/src/contextr/cli.py
@@ -39,6 +39,12 @@ def main(
         "--version",
         help="Show version and exit"
     ),
+    recent: bool = typer.Option(
+        False,
+        "-r",
+        "--recent",
+        help="Only include files modified in the last 7 days"
+    ),
 ):
     if version:
         console.print("contextr version 0.1.0", style="bold green")
@@ -49,7 +55,7 @@ def main(
         paths = ["."]
     
     try:
-        result = package_repository(paths, include_pattern=include)
+        result = package_repository(paths, include_pattern=include, recent=recent)
         
         if output:
             output_path = Path(output)

--- a/src/contextr/commands/package.py
+++ b/src/contextr/commands/package.py
@@ -93,7 +93,7 @@ def package_repository(
     # Recent Files Section (only include if there are recent files)
     recent_stats = {'total_lines': 0, 'processed_files': 0}
     if recent_files:
-        output_parts.append("## Recent Files\n")
+        output_parts.append("## Recent Changes\n")
         recent_stats = process_files_section(recent_files, repo_root, output_parts)
     
     # File Contents Section (all files if not recent mode, or skip if recent mode)
@@ -110,6 +110,7 @@ def package_repository(
     output_parts.append("## Summary")
     output_parts.append(f"- Total files: {processed_files}")
     output_parts.append(f"- Total lines: {total_lines}")
+    output_parts.append(f"- Recent files (last 7 days): {len(recent_files)}")
     if recent_files and not recent:
         output_parts.append(f"- Recent files (last 7 days): {recent_stats['processed_files']}")
     

--- a/test_recent.py
+++ b/test_recent.py
@@ -1,0 +1,11 @@
+# Test file to check recent functionality
+import datetime
+
+def test_function():
+    """This is a test function created recently"""
+    now = datetime.datetime.now()
+    print(f"Current time: {now}")
+    return now
+
+if __name__ == "__main__":
+    test_function()


### PR DESCRIPTION
## Idea
I would like to propose adding a new feature to the command-line interface: It will be a --recent or -r flag.

---

## Why adding this new feature
Usually when we work with LLMs and repository context packagers, it is useful to focus on files that have been modified recently, rather than packaging the entire repository. This helps to keep a relevant output rather than having everything.

---

## Proposed Behavior
- Add a --recent or -r flag to the CLI.
- When enabled, the tool should only include files modified within the last 7 days.
- This flag can be combined with other options (like --include or --output).
- Examples:
 ```
# Combining it with filters
uv run main.py  . --recent --include "*.py"

# Include files modified in the last 7 days (by default from our code)
uv run main.py --recent
 ```